### PR TITLE
update helfi_ahjo module git repo

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -75,12 +75,12 @@
             }
         },
         {
-            "name": "drupal/helfi_ahjo",
+            "name": "drupal/drupal-module-helfi-ahjo-org-chart",
             "type": "vcs",
-            "url": "git@github.com:city-of-helsinki/drupal-module-helfi-ahjo.git",
+            "url": "git@github.com:City-of-Helsinki/drupal-module-helfi-ahjo-org-chart.git",
             "extra": {
                 "username": "city-of-helsinki",
-                "repository": "drupal-module-helfi-ahjo",
+                "repository": "drupal-module-helfi-ahjo-org-chart",
                 "whitelisted": true
             }
         },


### PR DESCRIPTION
Changed drupal-module-helfi-ahjo (archived) repo for helfi_ahjo module with https://github.com/City-of-Helsinki/drupal-module-helfi-ahjo-org-chart