### PR TITLE
UHF-8255: Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,3 @@ See [documentation](/documentation) for more documentation.
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.